### PR TITLE
Fix for no re-render of project component

### DIFF
--- a/src/App/Home/Project/Project.js
+++ b/src/App/Home/Project/Project.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Component } from 'react'
 import QueryList from './components/QueryList'
 import { CardColumn, Row, Card } from '../../../utils/anvil'
 import EditableTask from './components/EditableTask'
@@ -8,12 +8,19 @@ import { graphql, compose } from 'react-apollo'
 
 import '../../../styles/index.css'
 
+const defaultState = {
+	selectedItem: null,
+	items: []
+}
+
 // Project: Component used on the /projects/:id route
-class Project extends React.Component {
-	state = {
-		selectedItem: null,
-		items: []
+class Project extends Component {
+
+	constructor(props) {
+		super(props)
+		this.state = defaultState
 	}
+
 	shouldComponentUpdate(nextProps, nextState) {
 		if (nextProps.data.project) {
 			nextState.items = this.getItems(nextProps.data.project)
@@ -59,7 +66,7 @@ class Project extends React.Component {
 		return (
 			<Row>
 			<CardColumn phoneInvisible={!!this.state.selectedItem}>
-				<QueryList 
+				<QueryList
 					items={this.state.items}
 					selectedItem={this.state.selectedItem}
 					selectItem={this.selectItem}
@@ -68,9 +75,9 @@ class Project extends React.Component {
 			{this.state.selectedItem &&
 			<CardColumn orderSm={-1}>
 				<Card>
-					<EditableTask 
-						item={this.state.selectedItem} 
-						onChange={this.onChange} 
+					<EditableTask
+						item={this.state.selectedItem}
+						onChange={this.onChange}
 						selectItem={this.selectItem}
 						location={this.props.location.pathname} />
 				</Card>

--- a/src/App/components/sidebar.js
+++ b/src/App/components/sidebar.js
@@ -8,12 +8,12 @@ class Sidenav extends React.Component {
 	render() {
 		return (
 			<AnvilSidebar.Pushable as={Segment} >
-				<Sidebar 
-					as={Menu} 
-					animation='push' 
-					width='wide' 
-					visible={this.props.isOpen} 
-					icon='labeled' 
+				<Sidebar
+					as={Menu}
+					animation='push'
+					width='wide'
+					visible={this.props.isOpen}
+					icon='labeled'
 					onClick={this.props.toggleSidebar} vertical inverted>
 					<UserInfo user={this.props.user} />
 					<MenuProjects projects={this.props.user.projects}/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added state initialization with constructor. This enables re-rendering from a setState() call.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #3 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Needed to enable re-rendering of the component when nextProp change and page refresh.
Issue #3 

## How Has This Been Tested?
Tested manually with mock project data. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):