### PR TITLE
Delete Task and Caching issues

### DIFF
--- a/src/App/Home/Project/Project.js
+++ b/src/App/Home/Project/Project.js
@@ -20,7 +20,7 @@ class Project extends Component {
 		super(props)
 		this.state = defaultState
 	}
-
+	
 	shouldComponentUpdate(nextProps, nextState) {
 		if (nextProps.data.project) {
 			nextState.items = this.getItems(nextProps.data.project)
@@ -30,6 +30,7 @@ class Project extends Component {
 
 	selectItem = (value) => {
 		this.setState({selectedItem: value})
+		this.props.data.refetch()
 	}
 
 	getItems(project) {
@@ -40,6 +41,7 @@ class Project extends Component {
 			}))
 		}))
 	}
+
 
 	onChange = ({key, value}) => {
 		let selectedItem = this.state.selectedItem
@@ -55,7 +57,7 @@ class Project extends Component {
 	}
 
 	render() {
-		if (this.props.data.loading) {
+		if (this.props.data.loading && !this.props.data.project) {
 			return (<div>Loading</div>)
 		}
 
@@ -63,6 +65,7 @@ class Project extends Component {
 			console.log(this.props.data.error)
 			return (<div>An unexpected error occurred</div>)
 		}
+
 		return (
 			<Row>
 			<CardColumn phoneInvisible={!!this.state.selectedItem}>

--- a/src/App/Home/Project/components/EditableTask.js
+++ b/src/App/Home/Project/components/EditableTask.js
@@ -18,14 +18,14 @@ class EditableTask extends Component {
 			{ key: 'trash', text: 'Delete', icon: 'trash', value: 'delete' }
 		]
 
-		const handleChange = (e, { value }) => {
+		const handleChange = async (e, { value }) => {
 			if(value === 'delete'){
-				console.log(this.props.item.data)
-				this.props.deleteTask({
+				await this.props.deleteTask({
 					variables: {
 						id: this.props.item.data.id
 					}
 				})
+				this.props.selectItem(null)
 			}
 		}
 		

--- a/src/graphql/client.js
+++ b/src/graphql/client.js
@@ -30,7 +30,7 @@ const cache = new InMemoryCache()
 
 // TODO: @nicklewanowicz: update to indexdb using somthing like https://github.com/localForage/localForage
 // this conditional is so tests wont fail on localstorage
-if(false || window.localStorage){
+if(false && window.localStorage){
 	persistCache({
 		cache,
 		storage: window.localStorage,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Added deleteTask functionality in previous PR but due to caching the task deleted wouldnt be removed from localStorage so for the time being caching is being disabled.

- Fix to projects page so it will only display loading on first load not refetch's

- When you delete and item it will be 'deselected' which will trigger a refetch 


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This issue was not resolved early, it is resolved now #3 
This push to master resolves #14 as we can now delete tasks

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested (shoudl to automated testing)
## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/15663269/43109492-11cecb1c-8eb5-11e8-9b9e-8ebe3284b712.png)
